### PR TITLE
feat: Use an explicitly closeable async iterator

### DIFF
--- a/src/AsyncUtils.js
+++ b/src/AsyncUtils.js
@@ -20,30 +20,32 @@ export async function* filter<T>(
 }
 
 export type AsyncQueueOptions = {
-  setup?: () => Promise<void> | void,
-  teardown?: () => void,
+  setup?: () => void | Promise<void>,
+  teardown?: () => void | Promise<void>,
+};
+
+type CloseableAsyncIterator<T> = AsyncIterator<T> & {
+  close: () => Promise<void>,
 };
 
 export class AsyncQueue {
-  values: any[];
-  closed: boolean = false;
-  promise: Promise<void>;
   options: AsyncQueueOptions;
+
+  values: any[];
+  promise: Promise<void>;
   resolvePromise: () => void;
-  iterable: Promise<AsyncGenerator<any, void, void>>;
+
+  closed: boolean;
+  iterator: Promise<CloseableAsyncIterator<any>>;
 
   constructor(options?: AsyncQueueOptions = {}) {
-    this.values = [];
     this.options = options;
+
+    this.values = [];
     this.createPromise();
 
-    this.iterable = this.createIterable();
-  }
-
-  close(): void | Promise<void> {
-    if (this.closed) return;
-    this.closed = true;
-    if (this.options.teardown) this.options.teardown();
+    this.closed = false;
+    this.iterator = this.createIterator();
   }
 
   createPromise() {
@@ -52,37 +54,51 @@ export class AsyncQueue {
     });
   }
 
-  async *createIterableRaw(): AsyncGenerator<any, void, void> {
-    try {
-      if (this.options.setup) await this.options.setup();
-      yield null;
+  async createIterator(): Promise<CloseableAsyncIterator<any>> {
+    const iterator = this.createIteratorRaw();
 
-      while (true) {
-        await this.promise;
+    // Wait for setup.
+    await iterator.next();
 
-        for (const value of this.values) {
-          yield value;
-        }
-
-        this.values.length = 0;
-        this.createPromise();
-      }
-    } finally {
-      await this.close();
-    }
+    const closeableIterator: CloseableAsyncIterator<any> = (iterator: any);
+    closeableIterator.close = this.close;
+    return closeableIterator;
   }
 
-  async createIterable(): Promise<AsyncGenerator<any, void, void>> {
-    const iterableRaw = this.createIterableRaw();
+  async *createIteratorRaw(): AsyncIterator<any> {
+    if (this.options.setup) {
+      await this.options.setup();
+    }
 
-    // wait for the first synthetic yield after setup
-    await iterableRaw.next();
+    yield null;
 
-    return iterableRaw;
+    while (true) {
+      await this.promise;
+
+      for (const value of this.values) {
+        if (this.closed) {
+          return;
+        }
+
+        yield value;
+      }
+
+      this.values.length = 0;
+      this.createPromise();
+    }
   }
 
   push(value: any) {
     this.values.push(value);
     this.resolvePromise();
   }
+
+  close = async (): Promise<void> => {
+    if (this.options.teardown) {
+      await this.options.teardown();
+    }
+
+    this.closed = true;
+    this.push(null);
+  };
 }

--- a/src/AuthorizedSocketConnection.js
+++ b/src/AuthorizedSocketConnection.js
@@ -251,8 +251,8 @@ export default class AuthorizedSocketConnection<TContext, TCredentials> {
 
     await Promise.all([
       this.config.credentialsManager.unauthenticate(),
-      ...Array.from(this.subscriptionContexts.values()).map(
-        subscriptionContext => subscriptionContext.close(),
+      ...Array.from(this.subscriptionContexts.values(), subscriptionContext =>
+        subscriptionContext.close(),
       ),
     ]);
   };

--- a/src/CredentialsManager.js
+++ b/src/CredentialsManager.js
@@ -2,6 +2,6 @@
 
 export interface CredentialsManager<TCredentials> {
   getCredentials(): ?TCredentials;
-  authenticate(authorization: string): Promise<mixed>;
-  unauthenticate(): Promise<mixed>; // allow for redis etc down the line
+  authenticate(authorization: string): void | Promise<void>;
+  unauthenticate(): void | Promise<void>; // allow for redis etc down the line
 }

--- a/src/EventSubscriber.js
+++ b/src/EventSubscriber.js
@@ -60,8 +60,7 @@ export default class EventSubscriber implements Subscriber {
     });
 
     eventQueues.add(queue);
-
-    return queue.iterator;
+    return queue;
   }
 
   close() {

--- a/src/EventSubscriber.js
+++ b/src/EventSubscriber.js
@@ -61,10 +61,10 @@ export default class EventSubscriber implements Subscriber {
 
     eventQueues.add(queue);
 
-    return queue.iterable;
+    return queue.iterator;
   }
 
-  async close() {
+  close() {
     this._listeners.forEach((fn, event) => {
       this.emitter.removeListener(event, fn);
     });

--- a/src/JwtCredentialsManager.js
+++ b/src/JwtCredentialsManager.js
@@ -50,7 +50,7 @@ export default class JwtCredentialsManager<TCredentials: JwtCredentials>
     await this.updateCredentials();
   }
 
-  async unauthenticate() {
+  unauthenticate() {
     if (this.renewHandle) {
       clearTimeout(this.renewHandle);
     }

--- a/src/RedisSubscriber.js
+++ b/src/RedisSubscriber.js
@@ -73,7 +73,7 @@ export default class RedisSubscriber implements Subscriber {
 
     channelQueues.add(queue);
 
-    const iterable = await queue.iterable;
+    const iterable = await queue.iterator;
     if (!parseMessage) return iterable;
 
     return map(iterable, parseMessage);

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -1,6 +1,6 @@
 /** @flow */
 
 export interface Subscriber {
-  subscribe(...any[]): Promise<AsyncGenerator<any, void, void>>;
+  subscribe(...any[]): Promise<AsyncIterable<any>>;
   close(): void | Promise<void>;
 }

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -1,6 +1,8 @@
 /** @flow */
 
 export interface Subscriber {
-  subscribe(...any[]): Promise<AsyncIterable<any>>;
+  subscribe(
+    ...any[]
+  ): { iterator: Promise<AsyncIterator<any>>, close: () => Promise<void> };
   close(): void | Promise<void>;
 }

--- a/src/SubscriptionContext.js
+++ b/src/SubscriptionContext.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import type { Subscriber } from './Subscriber';
+
+type MaybeCloseableAsyncIterable<T> = AsyncIterable<T> & {
+  close?: () => Promise<void>,
+};
+
+export default class SubscriptionContext {
+  subscriber: Subscriber;
+  iterables: Array<Promise<MaybeCloseableAsyncIterable<any>>>;
+
+  constructor(subscriber: Subscriber) {
+    this.subscriber = subscriber;
+    this.iterables = [];
+  }
+
+  subscribe(...args: any[]): Promise<AsyncIterable<any>> {
+    const iterable = this.subscriber.subscribe(...args);
+    this.iterables.push(iterable);
+    return iterable;
+  }
+
+  async close(): Promise<void> {
+    await Promise.all(
+      this.iterables.map(async iterablePromise => {
+        const iterable = await iterablePromise;
+        if (!iterable.close) {
+          return null;
+        }
+
+        return iterable.close();
+      }),
+    );
+  }
+}

--- a/test/AsyncQueue.test.js
+++ b/test/AsyncQueue.test.js
@@ -34,7 +34,7 @@ describe('AsyncQueue', () => {
 
     queue.push(5);
     await iter.next();
-    await iter.close();
+    await queue.close();
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -46,12 +46,11 @@ describe('AsyncQueue', () => {
     const queue = new AsyncQueue({ setup: setupSpy, teardown: teardownSpy });
     queue.push(5);
 
-    const closeableIter = await queue.iterator;
-    const iter = map(closeableIter, v => v + 1);
+    const iter = map(await queue.iterator, v => v + 1);
 
     expect((await iter.next()).value).toEqual(6);
 
-    await closeableIter.close();
+    await queue.close();
 
     expect(setupSpy).toHaveBeenCalled();
     expect(teardownSpy).toHaveBeenCalled();

--- a/test/RedisSubscriber.test.js
+++ b/test/RedisSubscriber.test.js
@@ -8,7 +8,8 @@ describe('RedisSubscriber', () => {
     const channel = 'whatever';
     const client = new RedisSubscriber();
 
-    const sub = await client.subscribe(channel);
+    const subscriptionContext = new SubscriptionContext(client);
+    const sub = await subscriptionContext.subscribe(channel);
 
     client.redis.publish(channel, 'foo');
 
@@ -23,7 +24,8 @@ describe('RedisSubscriber', () => {
     const channel = 'whatever';
     const client = new RedisSubscriber({ parseMessage: d => JSON.parse(d) });
 
-    const sub = await client.subscribe(channel);
+    const subscriptionContext = new SubscriptionContext(client);
+    const sub = await subscriptionContext.subscribe(channel);
 
     client.redis.publish(channel, '[1,2,3]');
 
@@ -38,8 +40,9 @@ describe('RedisSubscriber', () => {
     const channel = 'whatever';
     const client = new RedisSubscriber();
 
-    const subA = await client.subscribe(channel, d => JSON.parse(d));
-    const subB = await client.subscribe('another');
+    const subscriptionContext = new SubscriptionContext(client);
+    const subA = await subscriptionContext.subscribe(channel, JSON.parse);
+    const subB = await subscriptionContext.subscribe('another');
 
     client.redis.publish(channel, '[1,2,3]');
     client.redis.publish('another', '[1,2,3]');

--- a/test/RedisSubscriber.test.js
+++ b/test/RedisSubscriber.test.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import RedisSubscriber from '../src/RedisSubscriber';
+import SubscriptionContext from '../src/SubscriptionContext';
 
 describe('RedisSubscriber', () => {
   it('should subscribe for messages', async () => {
@@ -56,19 +57,16 @@ describe('RedisSubscriber', () => {
     const channel = 'channel';
     const client = new RedisSubscriber();
 
-    const sub = await client.subscribe(channel);
+    const subscriptionContext = new SubscriptionContext(client);
+    const sub = await subscriptionContext.subscribe(channel);
 
     client.redis.publish(channel, '');
     client.redis.publish(channel, '');
 
     let count = 0;
-    for (
-      let s = await sub.next();
-      !s.done;
-      s = await sub.next() // eslint-disable-line no-await-in-loop
-    ) {
+    for await (const _ of sub) {
       count++;
-      await sub.return();
+      await subscriptionContext.close();
       if (count === 2) throw new Error('Should not hit here');
     }
 


### PR DESCRIPTION
The return method on async generators is just too broken.