### PR TITLE
fix: await credentials when subscribing

### DIFF
--- a/src/AsyncUtils.ts
+++ b/src/AsyncUtils.ts
@@ -11,10 +11,10 @@ export async function* map<T, U>(
 
 export async function* filter<T>(
   iterable: AsyncIterable<T>,
-  predicate: (value: T) => boolean,
+  predicate: (value: T) => Promise<boolean> | boolean,
 ): AsyncGenerator<T, void, void> {
   for await (const value of iterable) {
-    if (predicate(value)) yield value;
+    if (await predicate(value)) yield value;
   }
 }
 

--- a/src/AuthorizedSocketConnection.ts
+++ b/src/AuthorizedSocketConnection.ts
@@ -94,11 +94,11 @@ export default class AuthorizedSocketConnection<TContext, TCredentials> {
     this.socket.emit('app_error', error);
   }
 
-  isAuthorized(
+  async isAuthorized(
     data: any,
     hasPermission: (data: any, credentials: TCredentials) => boolean,
   ) {
-    const credentials = this.config.credentialsManager.getCredentials();
+    const credentials = await this.config.credentialsManager.getCredentials();
     const isAuthorized = !!credentials && hasPermission(data, credentials);
     if (!isAuthorized) {
       this.log('info', 'unauthorized', {
@@ -239,7 +239,7 @@ export default class AuthorizedSocketConnection<TContext, TCredentials> {
     const stream: AsyncIterable<unknown> = resultOrStream as any;
 
     for await (const payload of stream) {
-      const credentials = this.config.credentialsManager.getCredentials();
+      const credentials = await this.config.credentialsManager.getCredentials();
 
       let response;
       try {

--- a/src/CredentialsManager.ts
+++ b/src/CredentialsManager.ts
@@ -1,5 +1,5 @@
 export interface CredentialsManager<TCredentials> {
-  getCredentials(): TCredentials | null | undefined;
+  getCredentials(): Promise<TCredentials | null | undefined>;
   authenticate(authorization: string): void | Promise<void>;
   unauthenticate(): void | Promise<void>; // allow for redis etc down the line
 }

--- a/src/JwtCredentialsManager.ts
+++ b/src/JwtCredentialsManager.ts
@@ -31,8 +31,6 @@ export default abstract class JwtCredentialsManager<
   }
 
   async getCredentials(): Promise<TCredentials | null | undefined> {
-    if (!this.credentialsPromise) return null;
-
     const credentials = await this.credentialsPromise;
     if (credentials && Date.now() >= credentials.exp * SECONDS_TO_MS) {
       return null;

--- a/src/JwtCredentialsManager.ts
+++ b/src/JwtCredentialsManager.ts
@@ -70,11 +70,6 @@ export default abstract class JwtCredentialsManager<
     );
     await this.credentialsPromise;
 
-    // Avoid race conditions with multiple updates.
-    if (this.token !== token) {
-      return;
-    }
-
     // TODO: Don't schedule renewal if the new credentials are expired or
     // almost expired.
     this.scheduleRenewCredentials();

--- a/src/JwtCredentialsManager.ts
+++ b/src/JwtCredentialsManager.ts
@@ -88,11 +88,10 @@ export default abstract class JwtCredentialsManager<
     }
 
     const { tokenExpirationMarginSeconds } = this.config;
-    if (tokenExpirationMarginSeconds === null) {
+    if (tokenExpirationMarginSeconds === null || !this.credentials) {
       return;
     }
 
-    if (!this.credentials) return;
     const resolvedCredentials = await this.credentials;
     if (!resolvedCredentials) return;
 


### PR DESCRIPTION
I think this should do the trick, though tbh I'm not quite sure if this is what you were suggesting (and also whether this means a major version bump from changing the interface to `CredentialsManager`).