### PR TITLE
fix: force patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@4c/graphql-subscription-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "4Catalyzer"
   },


### PR DESCRIPTION
Force a release for socket io 3 release

Will technically be a major release but I incorrectly bumped the version in the `package.json` in the socket io 3 renovate PR